### PR TITLE
add version limitation to flake8 to avoid runtime error

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -51,7 +51,7 @@ detached = true
 dependencies = [
     "bandit[toml]",
     "black",
-    "flake8",
+    "flake8<6.0.0",
     "flake8-copyright",
     "flake8-return",
     "flake8-print",


### PR DESCRIPTION
# What's changed

- To avoid runtime error with flake8, add version limitation (less than version 6.0.0)

## Reason

- flake8-copyright has issue against flake8 6.x
    - https://github.com/savoirfairelinux/flake8-copyright/issues/19
 